### PR TITLE
Fixed typo. "enerative AI" -> "generative AI"

### DIFF
--- a/_posts/2025-06-24-LLMsBringNewNatureOfAbstraction.md
+++ b/_posts/2025-06-24-LLMsBringNewNatureOfAbstraction.md
@@ -2,7 +2,7 @@
 title: LLMは新しい抽象化をもたらす
 original_page_name: 2025-nature-abstraction.html
 tags:
-  - enerative AI
+  - generative AI
   - article
 ---
 


### PR DESCRIPTION
下記ページのタグが"enerative AI"と設定されているのを"generative AI"に修正しました。
https://bliki-ja.github.io/LLMsBringNewNatureOfAbstraction

原文も"generative AI"と設定されています。
https://martinfowler.com/articles/2025-nature-abstraction.html